### PR TITLE
add VERSION line to module (required for current VERSION setting scheme)

### DIFF
--- a/lib/Test/DiagINC.pm
+++ b/lib/Test/DiagINC.pm
@@ -2,7 +2,8 @@ use 5.006;
 
 package Test::DiagINC;
 # ABSTRACT: List modules and versions loaded if tests fail
-# VERSION
+
+our $VERSION = '0.004';
 
 # If the tested module did not load strict/warnings we do not want
 # to load them either. On the other hand we would like to know our


### PR DESCRIPTION
* fixes "[DZ] no version was ever set"

This is similar to File::chdir [GH#5](https://github.com/dagolden/File-chdir/issues/5).
