### PR TITLE
delete %ENV entries after localizing them to bypass taint

### DIFF
--- a/lib/Test/DiagINC.pm
+++ b/lib/Test/DiagINC.pm
@@ -28,10 +28,15 @@ sub _max_length {
 # Requires %ENV cleanup to work under taint mode
 my $REALPATH_CWD = do {
     local $ENV{PATH};
+    delete $ENV{PATH};
     local $ENV{IFS};
+    delete $ENV{IFS};
     local $ENV{CDPATH};
+    delete $ENV{CDPATH};
     local $ENV{ENV};
+    delete $ENV{ENV};
     local $ENV{BASH_ENV};
+    delete $ENV{BASH_ENV};
     my ($perl) = $^X =~ /(.+)/; # $^X is internal how could it be tainted?!
     `"$perl" -MCwd -le "print getcwd"`;
 };


### PR DESCRIPTION
Doing local $ENV{$var} localizes the environment variable, but also sets
it to undef, which for an env var means setting it to an empty string.
Some environment variables are problematic when set to an empty string.
For example, an empty PATH is equivalent to '.', the current directory,
which makes it vulnerable to anything in the current directory. Future
versions of perl will complain about a PATH set to an empty string or
undef when run under taint mode.

Deleting PATH after localizing it will avoid this problem. For
consistency, just delete all of the env vars.